### PR TITLE
Add support for rust-miniscript

### DIFF
--- a/bitcoind/src/client_versions.rs
+++ b/bitcoind/src/client_versions.rs
@@ -1,73 +1,73 @@
 // All features uses 26_0
 #[cfg(feature = "26_0")]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v26::Client, json::v26 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v26::{Client, AddressType}, json::v26 as json};
 
 #[cfg(all(feature = "25_2", not(feature = "26_0")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v25::Client, json::v25 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v25::{Client, AddressType}, json::v25 as json};
 
 #[cfg(all(feature = "25_1", not(feature = "25_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v25::Client, json::v25 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v25::{Client, AddressType}, json::v25 as json};
 
 #[cfg(all(feature = "25_0", not(feature = "25_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v25::Client, json::v25 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v25::{Client, AddressType}, json::v25 as json};
 
 #[cfg(all(feature = "24_2", not(feature = "25_0")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v24::Client, json::v24 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v24::{Client, AddressType}, json::v24 as json};
 
 #[cfg(all(feature = "24_1", not(feature = "24_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v24::Client, json::v24 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v24::{Client, AddressType}, json::v24 as json};
 
 #[cfg(all(feature = "24_0_1", not(feature = "24_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v24::Client, json::v24 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v24::{Client, AddressType}, json::v24 as json};
 
 #[cfg(all(feature = "23_2", not(feature = "24_0_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v23::Client, json::v23 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v23::{Client, AddressType}, json::v23 as json};
 
 #[cfg(all(feature = "23_1", not(feature = "23_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v23::Client, json::v23 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v23::{Client, AddressType}, json::v23 as json};
 
 #[cfg(all(feature = "23_0", not(feature = "23_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v23::Client, json::v23 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v23::{Client, AddressType}, json::v23 as json};
 
 #[cfg(all(feature = "22_1", not(feature = "23_0")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v22::Client, json::v22 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v22::{Client, AddressType}, json::v22 as json};
 
 #[cfg(all(feature = "22_0", not(feature = "22_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v22::Client, json::v22 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v22::{Client, AddressType}, json::v22 as json};
 
 #[cfg(all(feature = "0_21_2", not(feature = "22_0")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v21::Client, json::v21 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v21::{Client, AddressType}, json::v21 as json};
 
 #[cfg(all(feature = "0_20_2", not(feature = "0_21_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v20::Client, json::v20 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v20::{Client, AddressType}, json::v20 as json};
 
 #[cfg(all(feature = "0_19_1", not(feature = "0_20_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v19::Client, json::v19 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v19::{Client, AddressType}, json::v19 as json};
 
 #[cfg(all(feature = "0_18_1", not(feature = "0_19_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v18::Client, json::v18 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v18::{Client, AddressType}, json::v18 as json};
 
 #[cfg(all(feature = "0_17_2", not(feature = "0_18_1")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v17::Client, json::v17 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v17::{Client, AddressType}, json::v17 as json};
 
 // To make --no-default-features work we have to enable some feature, use most recent version same as for default.
 #[cfg(all(not(feature = "26_0"), not(feature = "25_2"), not(feature = "25_1"), not(feature = "25_0"), not(feature = "24_2"),not(feadure = "24_1"), not(feature = "24_0_1"), not(feature = "23_2"), not(feature = "23_1"), not(feature = "23_0"), not(feature = "22_1"), not(feature = "22_0"), not(feature = "0_21_2"), not(feature = "0_20_2"), not(feature = "0_19_1"), not(feature = "0_18_1"), not(feature = "0_17_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
-pub use bitcoind_json_rpc_client::{client_sync::v26::Client, json::v26 as json};
+pub use bitcoind_json_rpc_client::{client_sync::v26::{Client, AddressType}, json::v26 as json};

--- a/bitcoind/src/lib.rs
+++ b/bitcoind/src/lib.rs
@@ -1,8 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "doc", cfg_attr(all(), doc = include_str!("../README.md")))]
 
+pub extern crate bitcoind_json_rpc_client as client;
+
 #[rustfmt::skip]
-mod client;
+mod client_versions;
 mod versions;
 
 use std::ffi::OsStr;
@@ -18,9 +20,11 @@ use log::{debug, error, warn};
 use tempfile::TempDir;
 pub use {anyhow, tempfile, which};
 
-use self::client::Client;
-#[allow(unused_imports)]         // for --no-default-features
-use self::versions::VERSION;
+#[rustfmt::skip]                // Keep pubic re-exports separate.
+pub use self::{
+    client_versions::{json, Client, AddressType},
+    versions::VERSION,
+};
 
 #[derive(Debug)]
 /// Struct representing the bitcoind process with related information
@@ -686,8 +690,6 @@ mod test {
     #[test]
     fn test_multi_wallet() {
         use bitcoind_json_rpc_client::bitcoin::Amount;
-
-        use crate::client::json;
 
         let exe = init();
         let bitcoind = BitcoinD::new(exe).unwrap();

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -8,10 +8,12 @@ pub mod blockchain;
 pub mod control;
 pub mod generating;
 pub mod network;
+pub mod raw_transactions;
 pub mod wallet;
 
 use bitcoin::address::{Address, NetworkChecked};
 use bitcoin::{Amount, Block, BlockHash, Txid};
+use serde::{Deserialize, Serialize};
 
 use crate::client_sync::{handle_defaults, into_json};
 use crate::json::v17::*;
@@ -34,6 +36,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [170200] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v17__unloadwallet!();
@@ -41,3 +46,25 @@ crate::impl_client_v17__loadwallet!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__getbalance!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+/// Argument to the `Client::get_new_address_with_type` function.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum AddressType {
+    Legacy,
+    P2ShSegwit,
+    Bech32,
+}
+
+impl fmt::Display for AddressType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use AddressType::*;
+
+        let s = match *self {
+            Legacy => "legacy",
+            P2ShSegwit => "p2sh-segwit",
+            Bech32 => "bech32",
+        };
+        fmt::Display::fmt(s, f)
+    }
+}

--- a/client/src/client_sync/v17/raw_transactions.rs
+++ b/client/src/client_sync/v17/raw_transactions.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Rawtransactions ==` section of the
+//! API docs of `bitcoind v0.17.1`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements bitcoind JSON-RPC API method `sendrawtransaction`
+#[macro_export]
+macro_rules! impl_client_v17__sendrawtransaction {
+    () => {
+        impl Client {
+            pub fn send_raw_transaction(
+                &self,
+                tx: &bitcoin::Transaction,
+            ) -> Result<SendRawTransaction> {
+                self.call("sendrawtransaction", &[into_json(tx)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v18.rs
+++ b/client/src/client_sync/v18.rs
@@ -28,6 +28,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [180100] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v17__unloadwallet!();
@@ -35,3 +38,6 @@ crate::impl_client_v17__loadwallet!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__getbalance!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v17::AddressType;

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -30,6 +30,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [190100] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v17__unloadwallet!();
@@ -38,3 +41,6 @@ crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v17::AddressType;

--- a/client/src/client_sync/v20.rs
+++ b/client/src/client_sync/v20.rs
@@ -28,6 +28,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [200200] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v17__unloadwallet!();
@@ -36,3 +39,6 @@ crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v17::AddressType;

--- a/client/src/client_sync/v21.rs
+++ b/client/src/client_sync/v21.rs
@@ -18,15 +18,18 @@ crate::impl_client_v17__getbestblockhash!();
 crate::impl_client_v17__getblock!();
 crate::impl_client_v17__gettxout!();
 
-// == Network ==
-crate::impl_client_v17__getnetworkinfo!();
-crate::impl_client_check_expected_server_version!({ [210200] });
-
 // == Control ==
 crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+
+// == Network ==
+crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_check_expected_server_version!({ [210200] });
+
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
 
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
@@ -36,3 +39,6 @@ crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v17::AddressType;

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -30,6 +30,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [220000, 220100] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v22__unloadwallet!();
@@ -38,3 +41,6 @@ crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v17::AddressType;

--- a/client/src/client_sync/v23.rs
+++ b/client/src/client_sync/v23.rs
@@ -6,6 +6,7 @@
 
 use bitcoin::address::{Address, NetworkChecked};
 use bitcoin::{Amount, Block, BlockHash, Txid};
+use serde::{Deserialize, Serialize};
 
 use crate::client_sync::{handle_defaults, into_json};
 use crate::json::v23::*;
@@ -28,6 +29,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [230000, 230100, 230200] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v22__unloadwallet!();
@@ -36,3 +40,27 @@ crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+/// Argument to the `Client::get_new_address_with_type` function.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum AddressType {
+    Legacy,
+    P2ShSegwit,
+    Bech32,
+    Bech32m,
+}
+
+impl fmt::Display for AddressType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use AddressType::*;
+
+        let s = match *self {
+            Legacy => "legacy",
+            P2ShSegwit => "p2sh-segwit",
+            Bech32 => "bech32",
+            Bech32m => "bech32m",
+        };
+        fmt::Display::fmt(s, f)
+    }
+}

--- a/client/src/client_sync/v24.rs
+++ b/client/src/client_sync/v24.rs
@@ -28,6 +28,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [240001, 240100, 240200] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v22__unloadwallet!();
@@ -36,3 +39,6 @@ crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v23::AddressType;

--- a/client/src/client_sync/v25.rs
+++ b/client/src/client_sync/v25.rs
@@ -28,6 +28,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [250000, 250100, 250200] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v22__unloadwallet!();
@@ -36,3 +39,6 @@ crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v23::AddressType;

--- a/client/src/client_sync/v26.rs
+++ b/client/src/client_sync/v26.rs
@@ -28,6 +28,9 @@ crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__getnetworkinfo!();
 crate::impl_client_check_expected_server_version!({ [260000] });
 
+// == Rawtransactions ==
+crate::impl_client_v17__sendrawtransaction!();
+
 // == Wallet ==
 crate::impl_client_v17__createwallet!();
 crate::impl_client_v22__unloadwallet!();
@@ -36,3 +39,6 @@ crate::impl_client_v17__getbalance!();
 crate::impl_client_v19__getbalances!();
 crate::impl_client_v17__getnewaddress!();
 crate::impl_client_v17__sendtoaddress!();
+crate::impl_client_v17__gettransaction!();
+
+pub use crate::client_sync::v23::AddressType;

--- a/integration_test/src/v17/mod.rs
+++ b/integration_test/src/v17/mod.rs
@@ -6,4 +6,5 @@ pub mod blockchain;
 pub mod control;
 pub mod generating;
 pub mod network;
+pub mod raw_transactions;
 pub mod wallet;

--- a/integration_test/src/v17/raw_transactions.rs
+++ b/integration_test/src/v17/raw_transactions.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing test methods on a JSON-RPC client.
+//!
+//! Specifically this is methods found under the `== Rawtransactions ==` section of the
+//! API docs of `bitcoind v0.17.1`.
+
+/// Requires `Client` to be in scope and to implement `get_best_block_hash`.
+#[macro_export]
+macro_rules! impl_test_v17__sendrawtransaction {
+    () => {
+        #[test]
+        fn send_raw_transaction() {
+            // let bitcoind = $crate::bitcoind_no_wallet();
+            // // TODO: Get a transaction from somewhere and send it.
+            // let _ = bitcoind.client.get_best_block_hash().expect("getbestblockhash");
+        }
+    };
+}

--- a/integration_test/src/v17/wallet.rs
+++ b/integration_test/src/v17/wallet.rs
@@ -60,7 +60,9 @@ macro_rules! impl_test_v17__getbalance {
     };
 }
 
-/// Requires `Client` to be in scope and to implement `send_to_address`.
+/// Requires `Client` to be in scope and to implement:
+/// - `generate_to_address`
+/// - `send_to_address`
 #[macro_export]
 macro_rules! impl_test_v17__sendtoaddress {
     () => {
@@ -72,12 +74,35 @@ macro_rules! impl_test_v17__sendtoaddress {
             let address = bitcoind.client.new_address().expect("failed to create new address");
             let _ = bitcoind.client.generate_to_address(101, &address).expect("generatetoaddress");
 
-            let balance = bitcoind.client.get_balance().expect("getbalance");
-
             let _ = bitcoind
                 .client
                 .send_to_address(&address, Amount::from_sat(10_000))
                 .expect("sendtoaddress");
+        }
+    };
+}
+
+/// Requires `Client` to be in scope and to implement:
+/// - `generate_to_address`
+/// - `send_to_address`
+/// - `get_transaction`
+#[macro_export]
+macro_rules! impl_test_v17__gettransaction {
+    () => {
+        #[test]
+        fn get_transaction() {
+            use bitcoin::Amount;
+
+            let bitcoind = $crate::bitcoind_with_default_wallet();
+            let address = bitcoind.client.new_address().expect("failed to create new address");
+            let _ = bitcoind.client.generate_to_address(101, &address).expect("generatetoaddress");
+
+            let txid = bitcoind
+                .client
+                .send_to_address(&address, Amount::from_sat(10_000))
+                .expect("sendtoaddress");
+
+            let _ = bitcoind.client.get_transaction(txid).expect("gettransaction");
         }
     };
 }

--- a/integration_test/tests/v17_api.rs
+++ b/integration_test/tests/v17_api.rs
@@ -35,6 +35,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -46,4 +53,6 @@ mod wallet {
     impl_test_v17__getnewaddress!();
     impl_test_v17__getbalance!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }
+

--- a/integration_test/tests/v18_api.rs
+++ b/integration_test/tests/v18_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -44,4 +51,5 @@ mod wallet {
     impl_test_v17__getnewaddress!();
     impl_test_v17__getbalance!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v19_api.rs
+++ b/integration_test/tests/v19_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v20_api.rs
+++ b/integration_test/tests/v20_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v21_api.rs
+++ b/integration_test/tests/v21_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v22_api.rs
+++ b/integration_test/tests/v22_api.rs
@@ -35,6 +35,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -46,4 +53,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v23_api.rs
+++ b/integration_test/tests/v23_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v24_api.rs
+++ b/integration_test/tests/v24_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v25_api.rs
+++ b/integration_test/tests/v25_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/integration_test/tests/v26_api.rs
+++ b/integration_test/tests/v26_api.rs
@@ -34,6 +34,13 @@ mod network {
     impl_test_v17__getnetworkinfo!();
 }
 
+// == Rawtransactions ==
+mod raw_transactions {
+    use super::*;
+
+    impl_test_v17__sendrawtransaction!();
+}
+
 // == Wallet ==
 mod wallet {
     use super::*;
@@ -45,4 +52,5 @@ mod wallet {
     impl_test_v17__getbalance!();
     impl_test_v19__getbalances!();
     impl_test_v17__sendtoaddress!();
+    impl_test_v17__gettransaction!();
 }

--- a/json/src/model/mod.rs
+++ b/json/src/model/mod.rs
@@ -32,8 +32,10 @@ pub use self::{
     },
     generating::GenerateToAddress,
     network::{GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork},
+    raw_transactions::SendRawTransaction,
     wallet::{
         CreateWallet, GetBalance, GetBalances, GetBalancesMine, GetBalancesWatchOnly,
-        GetNewAddress, LoadWallet, SendToAddress, UnloadWallet,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        LoadWallet, SendToAddress, UnloadWallet,
     },
 };

--- a/json/src/model/raw_transactions.rs
+++ b/json/src/model/raw_transactions.rs
@@ -4,3 +4,10 @@
 //!
 //! These structs model the types returned by the JSON-RPC API but have concrete types
 //! and are not specific to a specific version of Bitcoin Core.
+
+use bitcoin::Txid;
+use serde::{Deserialize, Serialize};
+
+/// Models the result of JSON-RPC method `sendrawtransaction`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SendRawTransaction(pub Txid);

--- a/json/src/model/wallet.rs
+++ b/json/src/model/wallet.rs
@@ -6,7 +6,7 @@
 //! and are not specific to a specific version of Bitcoin Core.
 
 use bitcoin::address::{Address, NetworkUnchecked};
-use bitcoin::{Amount, Txid};
+use bitcoin::{Amount, SignedAmount, Transaction, Txid};
 use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method  `createwallet`.
@@ -85,4 +85,42 @@ pub struct SendToAddress {
     pub txid: Txid,
     /// The transaction fee reason.
     pub fee_reason: String,
+}
+
+/// Models the result of JSON-RPC method `gettransaction`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetTransaction {
+    pub amount: Amount,
+    #[serde(default, with = "bitcoin::amount::serde::as_btc::opt")]
+    pub fee: Option<SignedAmount>,
+    pub confirmations: u32,
+    pub txid: Txid,
+    pub time: u64,
+    pub time_received: u64,
+    pub bip125_replaceable: String,
+    pub details: Vec<GetTransactionDetail>,
+    pub tx: Transaction,
+}
+
+/// Part of the `GetTransaction`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetTransactionDetail {
+    pub address: Address<NetworkUnchecked>,
+    pub category: GetTransactionDetailCategory,
+    pub amount: Amount,
+    pub label: Option<String>,
+    pub vout: u32,
+    #[serde(default, with = "bitcoin::amount::serde::as_btc::opt")]
+    pub fee: Option<SignedAmount>,
+    pub abandoned: Option<bool>,
+}
+
+/// Enum to represent the category of a transaction.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub enum GetTransactionDetailCategory {
+    Send,
+    Receive,
+    Generate,
+    Immature,
+    Orphan,
 }

--- a/json/src/v17/blockchain/convert.rs
+++ b/json/src/v17/blockchain/convert.rs
@@ -151,7 +151,7 @@ pub enum GetTxOutError {
     /// Conversion of the `best_block` field failed.
     BestBlock(hex::HexToArrayError),
     /// Conversion of the `value` field failed.
-    Value(amount::ParseAmountError),
+    Value(amount::ParseAmountError), // FIXME: Unused I thing
     /// Conversion of the `script_pubkey.hex` field failed.
     Hex(hex::HexToBytesError),
     /// Conversion of the `script_pubkey.address` field failed.

--- a/json/src/v17/mod.rs
+++ b/json/src/v17/mod.rs
@@ -109,7 +109,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaccount (Deprecated, will be removed in V0.18. To use this command, start bitcoind with -deprecatedrpc=accounts)`
 //! - [ ] `getreceivedbyaddress "address" ( minconf )`
-//! - [ ] `gettransaction "txid" ( include_watchonly )`
+//! - [x] `gettransaction "txid" ( include_watchonly )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -171,5 +171,9 @@ pub use self::{
     },
     generating::GenerateToAddress,
     network::{GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork},
-    wallet::{CreateWallet, GetBalance, GetNewAddress, LoadWallet, SendToAddress},
+    raw_transactions::SendRawTransaction,
+    wallet::{
+        CreateWallet, GetBalance, GetNewAddress, GetTransaction, GetTransactionDetail,
+        GetTransactionDetailCategory, LoadWallet, SendToAddress,
+    },
 };

--- a/json/src/v17/raw_transactions/convert.rs
+++ b/json/src/v17/raw_transactions/convert.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Convert stdlib (version specific) types to concrete types.
+//!
+//! This module does the conversion for `v0.17.1` types to the general concrete types.
+
+use bitcoin::{hex, Txid};
+
+use crate::{model, v17};
+
+impl TryFrom<v17::SendRawTransaction> for model::SendRawTransaction {
+    type Error = hex::HexToArrayError;
+
+    fn try_from(json: v17::SendRawTransaction) -> Result<Self, Self::Error> {
+        let txid = json.0.parse::<Txid>()?;
+        Ok(Self(txid))
+    }
+}

--- a/json/src/v17/raw_transactions/mod.rs
+++ b/json/src/v17/raw_transactions/mod.rs
@@ -3,3 +3,21 @@
 //! The JSON-RPC API for Bitcoin Core v0.17.1 - raw transactions.
 //!
 //! Types for methods found under the `== Rawtransactions ==` section of the API docs.
+
+mod convert;
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `sendrawtransaction`.
+///
+/// > sendrawtransaction "hexstring" ( allowhighfees )
+/// >
+/// > Submits raw transaction (serialized, hex-encoded) to local node and network.
+/// >
+/// > Also see createrawtransaction and signrawtransactionwithkey calls.
+/// >
+/// > Arguments:
+/// > 1. hexstring        (string, required) The hex string of the raw transaction
+/// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SendRawTransaction(pub String); // The hex encoded txid.

--- a/json/src/v17/wallet/convert.rs
+++ b/json/src/v17/wallet/convert.rs
@@ -4,10 +4,13 @@
 //!
 //! This module does the conversion for `v0.17.1` types to the general concrete types.
 
+use std::fmt;
 use std::str::FromStr;
 
 use bitcoin::amount::ParseAmountError;
-use bitcoin::{address, hex, Address, Amount, Txid};
+use bitcoin::consensus::encode;
+use bitcoin::{address, hex, Address, Amount, SignedAmount, Transaction, Txid};
+use internals::write_err;
 
 use crate::{model, v17};
 
@@ -51,5 +54,158 @@ impl TryFrom<v17::GetBalance> for model::GetBalance {
     fn try_from(json: v17::GetBalance) -> Result<Self, Self::Error> {
         let amount = Amount::from_btc(json.0)?;
         Ok(Self(amount))
+    }
+}
+
+impl TryFrom<v17::GetTransaction> for model::GetTransaction {
+    type Error = GetTransactionError;
+
+    fn try_from(json: v17::GetTransaction) -> Result<Self, Self::Error> {
+        use GetTransactionError as E;
+
+        let amount = Amount::from_btc(json.amount).map_err(E::Amount)?;
+        // FIMXE: Use combinators.
+        let fee = match json.fee {
+            None => None,
+            Some(f) => Some(SignedAmount::from_btc(f).map_err(E::Fee)?),
+        };
+        let txid = json.txid.parse::<Txid>().map_err(E::Txid)?;
+
+        let tx = encode::deserialize_hex::<Transaction>(&json.hex).map_err(E::Tx)?;
+        let mut details = vec![];
+        for detail in json.details {
+            let concrete = detail.try_into().map_err(E::Details)?;
+            details.push(concrete);
+        }
+
+        Ok(Self {
+            amount,
+            fee,
+            confirmations: json.confirmations,
+            txid,
+            time: json.time,
+            time_received: json.time_received,
+            bip125_replaceable: json.bip125_replaceable,
+            details,
+            tx,
+        })
+    }
+}
+
+/// Error when converting to a `v22::GetBlockchainInfo` type to a `concrete` type.
+#[derive(Debug)]
+pub enum GetTransactionError {
+    /// Conversion of the `amount` field failed.
+    Amount(ParseAmountError),
+    /// Conversion of the `fee` field failed.
+    Fee(ParseAmountError),
+    /// Conversion of the `txid` field failed.
+    Txid(hex::HexToArrayError),
+    /// Conversion of the transaction `hex` field failed.
+    Tx(encode::FromHexError),
+    /// Conversion of the `details` field failed.
+    Details(GetTransactionDetailError),
+}
+
+impl fmt::Display for GetTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GetTransactionError as E;
+
+        match *self {
+            E::Amount(ref e) => write_err!(f, "conversion of the `amount` field failed"; e),
+            E::Fee(ref e) => write_err!(f, "conversion of the `fee` field failed"; e),
+            E::Txid(ref e) => write_err!(f, "conversion of the `txid` field failed"; e),
+            E::Tx(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
+            E::Details(ref e) => write_err!(f, "conversion of the `details` field failed"; e),
+        }
+    }
+}
+
+impl std::error::Error for GetTransactionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GetTransactionError as E;
+
+        match *self {
+            E::Amount(ref e) => Some(e),
+            E::Fee(ref e) => Some(e),
+            E::Txid(ref e) => Some(e),
+            E::Tx(ref e) => Some(e),
+            E::Details(ref e) => Some(e),
+        }
+    }
+}
+
+impl TryFrom<v17::GetTransactionDetail> for model::GetTransactionDetail {
+    type Error = GetTransactionDetailError;
+
+    fn try_from(json: v17::GetTransactionDetail) -> Result<Self, Self::Error> {
+        use GetTransactionDetailError as E;
+
+        let address = Address::from_str(&json.address).map_err(E::Address)?;
+        let amount = Amount::from_btc(json.amount).map_err(E::Amount)?;
+        // FIMXE: Use combinators.
+        let fee = match json.fee {
+            None => None,
+            Some(f) => Some(SignedAmount::from_btc(f).map_err(E::Fee)?),
+        };
+
+        Ok(Self {
+            address,
+            category: json.category.into(),
+            amount,
+            label: json.label,
+            vout: json.vout,
+            fee,
+            abandoned: json.abandoned,
+        })
+    }
+}
+
+/// Error when converting to a `v22::GetTransactionDetail` type to a `concrete` type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GetTransactionDetailError {
+    /// Conversion of the `address` field failed.
+    Address(address::ParseError),
+    /// Conversion of the `fee` field failed.
+    Fee(ParseAmountError),
+    /// Conversion of the `amount` field failed.
+    Amount(ParseAmountError),
+}
+
+impl fmt::Display for GetTransactionDetailError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GetTransactionDetailError::*;
+
+        match *self {
+            Address(ref e) => write_err!(f, "conversion of the `address` field failed"; e),
+            Fee(ref e) => write_err!(f, "conversion of the `fee` field failed"; e),
+            Amount(ref e) => write_err!(f, "conversion of the `amount` field failed"; e),
+        }
+    }
+}
+
+impl std::error::Error for GetTransactionDetailError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GetTransactionDetailError as E;
+
+        match *self {
+            E::Address(ref e) => Some(e),
+            E::Fee(ref e) => Some(e),
+            E::Amount(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<v17::GetTransactionDetailCategory> for model::GetTransactionDetailCategory {
+    fn from(json: v17::GetTransactionDetailCategory) -> Self {
+        use v17::GetTransactionDetailCategory::*;
+
+        match json {
+            Send => model::GetTransactionDetailCategory::Send,
+            Receive => model::GetTransactionDetailCategory::Receive,
+            Generate => model::GetTransactionDetailCategory::Generate,
+            Immature => model::GetTransactionDetailCategory::Immature,
+            Orphan => model::GetTransactionDetailCategory::Orphan,
+        }
     }
 }

--- a/json/src/v17/wallet/mod.rs
+++ b/json/src/v17/wallet/mod.rs
@@ -88,3 +88,56 @@ pub struct SendToAddress {
     /// The transaction id.
     pub txid: String,
 }
+
+/// Result of the JSON-RPC method `gettransaction`.
+///
+/// > gettransaction "txid" ( include_watchonly )
+/// >
+/// > Get detailed information about in-wallet transaction `<txid>`
+/// >
+/// > Arguments:
+/// > 1. txid                 (string, required) The transaction id
+/// > 2. include_watchonly    (boolean, optional, default=false) Whether to include watch-only addresses in balance calculation and details[]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetTransaction {
+    pub amount: f64,
+    pub fee: Option<f64>,
+    pub confirmations: u32,
+    // FIXME: The docs say these two fields should be here but it is not returned.
+    //        Is it worth patching Core for a version this old?
+    //
+    // #[serde(rename = "blockhash")]
+    // pub block_hash: String,
+    // #[serde(rename = "blockindex")]
+    // pub block_index: u64,
+    pub txid: String,
+    pub time: u64,
+    #[serde(rename = "timereceived")]
+    pub time_received: u64,
+    #[serde(rename = "bip125-replaceable")]
+    pub bip125_replaceable: String,
+    pub details: Vec<GetTransactionDetail>,
+    pub hex: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetTransactionDetail {
+    pub address: String,
+    pub category: GetTransactionDetailCategory,
+    pub amount: f64,
+    pub label: Option<String>,
+    pub vout: u32,
+    pub fee: Option<f64>,
+    pub abandoned: Option<bool>,
+}
+
+/// Enum to represent the category of a transaction.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GetTransactionDetailCategory {
+    Send,
+    Receive,
+    Generate,
+    Immature,
+    Orphan,
+}

--- a/json/src/v18/mod.rs
+++ b/json/src/v18/mod.rs
@@ -111,7 +111,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf )`
 //! - [ ] `getreceivedbylabel "label" ( minconf )`
-//! - [ ] `gettransaction "txid" ( include_watchonly )`
+//! - [x] `gettransaction "txid" ( include_watchonly )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -156,6 +156,7 @@
 pub use crate::v17::{
     Bip9Softfork, Bip9SoftforkStatus, CreateWallet, GenerateToAddress, GetBalance,
     GetBestBlockHash, GetBlockVerbosityOne, GetBlockVerbosityZero, GetBlockchainInfo,
-    GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork, GetNewAddress, GetTxOut,
-    LoadWallet, ScriptPubkey, SendToAddress, Softfork, SoftforkReject,
+    GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork, GetNewAddress, GetTransaction,
+    GetTransactionDetail, GetTransactionDetailCategory, GetTxOut, LoadWallet, ScriptPubkey,
+    SendRawTransaction, SendToAddress, Softfork, SoftforkReject,
 };

--- a/json/src/v19/mod.rs
+++ b/json/src/v19/mod.rs
@@ -112,7 +112,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf )`
 //! - [ ] `getreceivedbylabel "label" ( minconf )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -169,5 +169,6 @@ pub use self::{
 pub use crate::v17::{
     CreateWallet, GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
     GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-    GetNewAddress, GetTxOut, LoadWallet, SendToAddress,
+    GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory, GetTxOut,
+    LoadWallet, SendRawTransaction, SendToAddress,
 };

--- a/json/src/v20/mod.rs
+++ b/json/src/v20/mod.rs
@@ -113,7 +113,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf )`
 //! - [ ] `getreceivedbylabel "label" ( minconf )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -160,7 +160,8 @@ pub use crate::{
     v17::{
         CreateWallet, GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut, LoadWallet, SendToAddress,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, LoadWallet, SendRawTransaction, SendToAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/json/src/v21/mod.rs
+++ b/json/src/v21/mod.rs
@@ -115,7 +115,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf )`
 //! - [ ] `getreceivedbylabel "label" ( minconf )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -166,7 +166,8 @@ pub use crate::{
     v17::{
         CreateWallet, GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut, LoadWallet, SendToAddress,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, LoadWallet, SendRawTransaction, SendToAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/json/src/v22/mod.rs
+++ b/json/src/v22/mod.rs
@@ -120,7 +120,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf )`
 //! - [ ] `getreceivedbylabel "label" ( minconf )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -177,7 +177,8 @@ pub use crate::{
     v17::{
         CreateWallet, GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut, LoadWallet,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, LoadWallet, SendRawTransaction,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/json/src/v23/mod.rs
+++ b/json/src/v23/mod.rs
@@ -115,7 +115,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf include_immature_coinbase )`
 //! - [ ] `getreceivedbylabel "label" ( minconf include_immature_coinbase )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -170,7 +170,8 @@ pub use crate::{
     v17::{
         CreateWallet, GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut, LoadWallet,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, LoadWallet, SendRawTransaction,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/json/src/v24/mod.rs
+++ b/json/src/v24/mod.rs
@@ -116,7 +116,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf include_immature_coinbase )`
 //! - [ ] `getreceivedbylabel "label" ( minconf include_immature_coinbase )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -174,7 +174,8 @@ pub use crate::{
     v17::{
         CreateWallet, GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut, LoadWallet,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, LoadWallet, SendRawTransaction,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/json/src/v25/mod.rs
+++ b/json/src/v25/mod.rs
@@ -117,7 +117,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf include_immature_coinbase )`
 //! - [ ] `getreceivedbylabel "label" ( minconf include_immature_coinbase )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -179,7 +179,8 @@ pub use crate::{
     v17::{
         GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, SendRawTransaction,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/json/src/v26/mod.rs
+++ b/json/src/v26/mod.rs
@@ -125,7 +125,7 @@
 //! - [ ] `getrawchangeaddress ( "address_type" )`
 //! - [ ] `getreceivedbyaddress "address" ( minconf include_immature_coinbase )`
 //! - [ ] `getreceivedbylabel "label" ( minconf include_immature_coinbase )`
-//! - [ ] `gettransaction "txid" ( include_watchonly verbose )`
+//! - [x] `gettransaction "txid" ( include_watchonly verbose )`
 //! - [ ] `getunconfirmedbalance`
 //! - [ ] `getwalletinfo`
 //! - [ ] `importaddress "address" ( "label" rescan p2sh )`
@@ -183,7 +183,8 @@ pub use crate::{
     v17::{
         GenerateToAddress, GetBalance, GetBestBlockHash, GetBlockVerbosityOne,
         GetBlockVerbosityZero, GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork,
-        GetNewAddress, GetTxOut,
+        GetNewAddress, GetTransaction, GetTransactionDetail, GetTransactionDetailCategory,
+        GetTxOut, SendRawTransaction,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,


### PR DESCRIPTION
Add everything needed to support the `bitcoind-tests` crate in `rust-miniscript` for all versions of Core that be support.