### PR TITLE
Bump version numbers

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-json-rpc-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bitcoin",
  "bitcoind-json-rpc-types",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-json-rpc-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitcoin",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-json-rpc-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bitcoin",
  "bitcoind-json-rpc-types",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-json-rpc-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitcoin",
  "bitcoin-internals",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2 - 2024-06-21
+
+- Fix bugs in `AddressType`
+
 # 0.2.1 - 2024-06-17
 
 - Enable all features in docs build.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind-json-rpc-client"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",

--- a/json/CHANGELOG.md
+++ b/json/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1 - 2024-06-21
+
+- Implement `into_model` on all types.
+
 # 0.2.0 - 2024-06-13
 
 - Use Bitcoin Core 0.17.1 (0.17.2 seems to not exist and have been a mistake).

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind-json-rpc-types"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",

--- a/regtest/CHANGELOG.md
+++ b/regtest/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2 - 2024-06-21
+
+- Call `into_model` when creating/loading wallet.
+
 # 0.2.1 - 2024-06-17
 
 Do various little fixes to try and make the docs on `Client` more legible, specifically to alleviate

--- a/regtest/Cargo.toml
+++ b/regtest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind-json-rpc-regtest"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/tcharding/rust-bitcoind-json-rpc"


### PR DESCRIPTION
We just did a bunch of changes to all three crates, in preparation for release add a changelog to each, bump the version number, and update the lock files.